### PR TITLE
Remove Bower from workflow in favour of NPM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,5 +21,5 @@
 Following tasks are there to help with development:
 
 - `npm start` (aka `npm run grunt watch:bdd`) listens to tests and source, reruns tests
-- `npm run grunt qa` run QA task that includes tests and JSHint
+- `npm test` (aka `npm run grunt qa`) run QA task that includes tests and JSHint
 - `npm run grunt build` minify source to dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@
 
 Following tasks are there to help with development:
 
-- `grunt watch:bdd` listens to tests and source, reruns tests
-- `grunt qa` run QA task that includes tests and JSHint
-- `grunt build` minify source to dist/
+- `npm run grunt watch:bdd` listens to tests and source, reruns tests
+- `npm run grunt qa` run QA task that includes tests and JSHint
+- `npm run grunt build` minify source to dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,6 @@
 
 Following tasks are there to help with development:
 
-- `npm run grunt watch:bdd` listens to tests and source, reruns tests
+- `npm start` (aka `npm run grunt watch:bdd`) listens to tests and source, reruns tests
 - `npm run grunt qa` run QA task that includes tests and JSHint
 - `npm run grunt build` minify source to dist/

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,6 @@
     "jquery": ">=1.11.3 <4.0.0"
   },
   "devDependencies": {
-    "mocha": "~3.2.0",
-    "chai": "~3.5.0"
   },
   "authors": [
     "Interactive Pioneers GmbH <hello@interactive-pioneers.de>"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   ],
   "license": "GPL-3.0",
   "bugs": "https://github.com/interactive-pioneers/iptools-jquery-validator/issues",
-  "dependencies": {},
+  "dependencies": {
+    "jquery": "^3.1.1"
+  },
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-concurrent": "~2.3.1",
@@ -42,7 +44,8 @@
     "time-grunt": "~1.4.0",
     "grunt-jscs": "~3.0.1",
     "bower": "~1.8.0",
-    "grunt-cli": "~1.2.0"
+    "grunt-cli": "~1.2.0",
+    "chai": "~3.5.0"
   },
   "engines": {
     "node": "~7.4.0"
@@ -53,9 +56,7 @@
   },
   "scripts": {
     "test": "npm run grunt travis --verbose",
-    "install": "npm run bower install",
     "start": "npm run grunt watch:bdd",
-    "bower": "bower",
     "grunt": "grunt"
   },
   "keywords": [

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>Mocha Spec Runner</title>
-  <link rel="stylesheet" href="../bower_components/mocha/mocha.css">
+  <link rel="stylesheet" href="../node_modules/mocha/mocha.css">
 </head>
 <body>
   <div id="mocha"></div>
@@ -22,9 +22,9 @@
     <input type="text" name="surname" data-validation="unique" data-validation-trigger="change" data-validation-errormsg-unique="Name should be unique." data-validation-unique-set="name" data-validation-unique-with="js_forename" id="js_surname">
   </form>
 
-  <script src="../bower_components/jquery/dist/jquery.min.js"></script>
-  <script src="../bower_components/mocha/mocha.js"></script>
-  <script src="../bower_components/chai/chai.js"></script>
+  <script src="../node_modules/jquery/dist/jquery.min.js"></script>
+  <script src="../node_modules/mocha/mocha.js"></script>
+  <script src="../node_modules/chai/chai.js"></script>
   <script>mocha.setup('bdd');</script>
   <script>var expect = chai.expect;</script>
   <script src="spec/unit.js"></script>


### PR DESCRIPTION
This is chiefly for the reasons of reliable Mocha tests. Bower adds another layer where `grunt-mocha` from NPM and Mocha from Bower may be incompatible and cause test failures.